### PR TITLE
Add /donate redirect

### DIFF
--- a/donate.md
+++ b/donate.md
@@ -1,0 +1,8 @@
+---
+title: Donate
+subtitle: Make a donation
+short_name: Donate
+permalink: /donate
+redirect_to: https://carlmont-high-school.square.site/product/donate-to-robotics/98?cp=true&sa=true&sbp=false&q=false
+new_window: true
+---

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: MORE THAN JUST THE ROBOT.
+title: MORE THAN JUST THE ROBOT
 subtitle: Carlmont High School FRC Team 199
 short_name: Home
 permalink: /


### PR DESCRIPTION
This redirects to a page which will only work when we've arranged to have a fundraising campaign with the school treasurer. That's why it isn't incorporated into the text of any of the pages.
